### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Remove EOL Python version from CI

Also removed 3.7 because it'll be EOL in 5 months.

Had to quote it because it interprets 3.10 as 3.1.