### PR TITLE
Added a utility class to simplify the integration of Healthchecks with Celery

### DIFF
--- a/healthchecks_wrapper/api.py
+++ b/healthchecks_wrapper/api.py
@@ -1,9 +1,13 @@
-"""Main module."""
 import asyncio
 import logging
 import socket
 from functools import partial
 from urllib.request import urlopen
+
+# Constants required by HealthChecks.io
+JOB_START_POST_FIX = "/start"
+JOB_END_POST_FIX = ""
+JOB_FAILURE_PATH = "/fail"
 
 TIMEOUT = 10
 

--- a/healthchecks_wrapper/api.py
+++ b/healthchecks_wrapper/api.py
@@ -1,0 +1,30 @@
+"""Main module."""
+import asyncio
+import logging
+import socket
+from functools import partial
+from urllib.request import urlopen
+
+TIMEOUT = 10
+
+logger = logging.getLogger(__name__)
+
+
+def send_request(health_check_url, text_message=None):
+    try:
+        urlopen(health_check_url, timeout=TIMEOUT, data=text_message)
+    except socket.error as e:
+        logger.info(f"Ping failed: {e}")
+
+
+async def asend_request(health_check_url, payload=None):
+    try:
+        pfunc = partial(
+            urlopen,
+            health_check_url,
+            timeout=TIMEOUT,
+            data=payload,
+        )
+        await asyncio.get_event_loop().run_in_executor(None, pfunc)
+    except socket.error as e:
+        logger.info(f"Ping failed: {e}")

--- a/healthchecks_wrapper/celery.py
+++ b/healthchecks_wrapper/celery.py
@@ -1,0 +1,56 @@
+import logging
+import sys
+import traceback
+
+from healthchecks_wrapper.api import send_request
+from healthchecks_wrapper.api import JOB_START_POST_FIX
+from healthchecks_wrapper.api import JOB_END_POST_FIX
+from healthchecks_wrapper.api import JOB_FAILURE_PATH
+
+logger = logging.getLogger(__name__)
+
+try:
+    import celery
+except ImportError:
+    logger.error("Cannot use the healthchecks_wrapper.celery without celery installed")
+    sys.exit(1)
+
+
+class HealthCheckTaskBase(celery.Task):
+    """Base class to use for celery tasks to report status to healthchecks.io
+
+    Attributes:
+        health_check_url (str): A valid url to send request
+        health_check_retry_as_failure (bool, optional): If True, a retry will be
+            reported as a failure. Defaults to False.
+
+    """
+
+    health_check_url = None
+    health_check_retry_as_failure = False
+
+    def __init__(self):
+        super().__init__()
+        if self.health_check_url is None:
+            raise ValueError("health_check_url must be set")
+
+    def before_start(self, task_id, args, kwargs):
+        send_request(self.health_check_url + JOB_START_POST_FIX)
+        return super().before_start(task_id, args, kwargs)
+
+    def on_success(self, retval, task_id, args, kwargs):
+        send_request(self.health_check_url + JOB_END_POST_FIX)
+        return super().on_success(retval, task_id, args, kwargs)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        stack_trace = "".join(traceback.format_exception(exc))
+        payload = stack_trace.encode("utf-8")
+        send_request(self.health_check_url + JOB_FAILURE_PATH, payload)
+        return super().on_failure(exc, task_id, args, kwargs, einfo)
+
+    def on_retry(self, exc, task_id, args, kwargs, einfo):
+        if self.health_check_retry_as_failure:
+            stack_trace = "".join(traceback.format_exception(exc))
+            payload = stack_trace.encode("utf-8")
+            send_request(self.health_check_url + JOB_FAILURE_PATH, payload)
+        return super().on_retry(exc, task_id, args, kwargs, einfo)

--- a/healthchecks_wrapper/context_manager.py
+++ b/healthchecks_wrapper/context_manager.py
@@ -1,5 +1,6 @@
 """Main module."""
 import asyncio
+import logging
 import traceback
 import socket
 from functools import partial
@@ -14,6 +15,7 @@ JOB_FAILURE_PATH = "/fail"
 
 TIMEOUT = 10
 
+logger = logging.getLogger(__name__)
 
 class HealthCheck:
     def __init__(self, health_check_url, suppress_exceptions=False):
@@ -46,7 +48,7 @@ class HealthCheck:
         try:
             urlopen(self.health_check_url + post_fix, timeout=10, data=text_message)
         except socket.error as e:
-            print("Ping failed: %s" % e)
+            logger.info(f"Ping failed: {e}")
 
     async def send_request_async(self, post_fix, payload=None):
         try:
@@ -55,7 +57,7 @@ class HealthCheck:
             )
             await asyncio.get_event_loop().run_in_executor(None, pfunc)
         except socket.error as e:
-            print("Ping failed: %s" % e)
+            logger.info(f"Ping failed: {e}")
 
     async def __aenter__(self):
         await self.send_request_async(JOB_START_POST_FIX)

--- a/healthchecks_wrapper/context_manager.py
+++ b/healthchecks_wrapper/context_manager.py
@@ -2,15 +2,13 @@
 import logging
 import traceback
 
-from .api import send_request, asend_request
+from .api import send_request
+from .api import asend_request
+from .api import JOB_START_POST_FIX
+from .api import JOB_END_POST_FIX
+from .api import JOB_FAILURE_PATH
+
 from .functions import is_invalid_url
-
-# Constants required by HealthChecks.io
-
-JOB_START_POST_FIX = "/start"
-JOB_END_POST_FIX = ""
-JOB_FAILURE_PATH = "/fail"
-
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Through this pull request, I would like to propose a utility to automate the call to Healthchecks when using Celery.

Implementing this feature requires a lot of refactoring, but it does not break the current behavior.

I am proposing this feature because for some of my projects, I want to use Healthchecks with Celery tasks. Instead of developing a new solution, I found it interesting to rely on your library and add support for Celery.

Here are the changes made so far:

- moving the send_request and send_request_async functions to a separate module
- renaming send_request_async to asend_request (to follow Python naming conventions)
- moving the JOB_* constants to a separate module
- creating a HealthCheckTaskBase class.

Here is an example of how to use it:

```python
from healthchecks_wrapper.celery import HealthCheckTaskBase

@app.task(
    base=HealthCheckTaskBase,
    health_check_url=" https://hc-ping.com/xxx-xxx-xxx-xxx",
)
def cron_that_do_something():
    ...
```
A ping to Healthchecks will be sent when the task starts, as well as when it finishes (whether it's a success or an error).

I still need to implement unit tests and improve the handling of the retry system provided by Celery (by offering several options). I will update this PR as I progress.

Aymeric